### PR TITLE
fix(preview): block iframe pointer events during panel resize

### DIFF
--- a/claude-code-projects/uigen/src/app/__tests__/main-content.test.tsx
+++ b/claude-code-projects/uigen/src/app/__tests__/main-content.test.tsx
@@ -1,0 +1,116 @@
+import { test, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MainContent } from "../main-content";
+
+vi.mock("@/lib/contexts/file-system-context", () => ({
+  FileSystemProvider: ({ children }: any) => <div>{children}</div>,
+  useFileSystem: vi.fn(() => ({
+    getAllFiles: () => new Map(),
+    refreshTrigger: 0,
+  })),
+}));
+
+vi.mock("@/lib/contexts/chat-context", () => ({
+  ChatProvider: ({ children }: any) => <div>{children}</div>,
+  useChat: vi.fn(() => ({
+    messages: [],
+    input: "",
+    handleInputChange: vi.fn(),
+    handleSubmit: vi.fn(),
+    status: "idle",
+  })),
+}));
+
+vi.mock("@/components/chat/ChatInterface", () => ({
+  ChatInterface: () => <div data-testid="chat-interface">Chat</div>,
+}));
+
+vi.mock("@/components/preview/PreviewFrame", () => ({
+  PreviewFrame: () => <div data-testid="preview-frame">Preview</div>,
+}));
+
+vi.mock("@/components/editor/FileTree", () => ({
+  FileTree: () => <div data-testid="file-tree">FileTree</div>,
+}));
+
+vi.mock("@/components/editor/CodeEditor", () => ({
+  CodeEditor: () => <div data-testid="code-editor">CodeEditor</div>,
+}));
+
+vi.mock("@/components/HeaderActions", () => ({
+  HeaderActions: () => <div data-testid="header-actions">Actions</div>,
+}));
+
+vi.mock("@/components/ui/resizable", () => ({
+  ResizablePanelGroup: ({ children, className }: any) => (
+    <div className={className}>{children}</div>
+  ),
+  ResizablePanel: ({ children }: any) => <div>{children}</div>,
+  ResizableHandle: () => <div />,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+test("shows preview view by default", () => {
+  render(<MainContent />);
+
+  expect(screen.getByTestId("preview-frame")).toBeDefined();
+  expect(screen.queryByTestId("code-editor")).toBeNull();
+});
+
+test("clicking Code tab switches to code view", async () => {
+  const user = userEvent.setup();
+  render(<MainContent />);
+
+  const codeTab = screen.getByRole("tab", { name: "Code" });
+  await user.click(codeTab);
+
+  expect(screen.getByTestId("code-editor")).toBeDefined();
+  expect(screen.queryByTestId("preview-frame")).toBeNull();
+});
+
+test("clicking Preview tab switches back to preview view", async () => {
+  const user = userEvent.setup();
+  render(<MainContent />);
+
+  const codeTab = screen.getByRole("tab", { name: "Code" });
+  await user.click(codeTab);
+
+  expect(screen.queryByTestId("preview-frame")).toBeNull();
+
+  const previewTab = screen.getByRole("tab", { name: "Preview" });
+  await user.click(previewTab);
+
+  expect(screen.getByTestId("preview-frame")).toBeDefined();
+  expect(screen.queryByTestId("code-editor")).toBeNull();
+});
+
+test("Preview tab is active by default", () => {
+  render(<MainContent />);
+
+  const previewTab = screen.getByRole("tab", { name: "Preview" });
+  expect(previewTab.getAttribute("data-state")).toBe("active");
+
+  const codeTab = screen.getByRole("tab", { name: "Code" });
+  expect(codeTab.getAttribute("data-state")).toBe("inactive");
+});
+
+test("Code tab becomes active after clicking it", async () => {
+  const user = userEvent.setup();
+  render(<MainContent />);
+
+  const codeTab = screen.getByRole("tab", { name: "Code" });
+  await user.click(codeTab);
+
+  expect(codeTab.getAttribute("data-state")).toBe("active");
+
+  const previewTab = screen.getByRole("tab", { name: "Preview" });
+  expect(previewTab.getAttribute("data-state")).toBe("inactive");
+});

--- a/claude-code-projects/uigen/src/app/main-content.tsx
+++ b/claude-code-projects/uigen/src/app/main-content.tsx
@@ -32,6 +32,7 @@ interface MainContentProps {
 
 export function MainContent({ user, project }: MainContentProps) {
   const [activeView, setActiveView] = useState<"preview" | "code">("preview");
+  const [isPanelDragging, setIsPanelDragging] = useState(false);
 
   return (
     <FileSystemProvider initialData={project?.data}>
@@ -53,7 +54,10 @@ export function MainContent({ user, project }: MainContentProps) {
               </div>
             </ResizablePanel>
 
-            <ResizableHandle className="w-[1px] bg-neutral-200 hover:bg-neutral-300 transition-colors" />
+            <ResizableHandle
+              className="w-[1px] bg-neutral-200 hover:bg-neutral-300 transition-colors"
+              onDragging={setIsPanelDragging}
+            />
 
             {/* Right Panel - Preview/Code */}
             <ResizablePanel defaultSize={65}>
@@ -77,8 +81,11 @@ export function MainContent({ user, project }: MainContentProps) {
                 {/* Content Area */}
                 <div className="flex-1 overflow-hidden bg-neutral-50">
                   {activeView === "preview" ? (
-                    <div className="h-full bg-white">
+                    <div className="relative h-full bg-white">
                       <PreviewFrame />
+                      {isPanelDragging && (
+                        <div className="absolute inset-0" />
+                      )}
                     </div>
                   ) : (
                     <ResizablePanelGroup


### PR DESCRIPTION
When dragging the resize handle between the chat and preview panels, the preview iframe can capture mouse events, causing the drag to break and leaving subsequent clicks (including the toggle tabs) unresponsive.

Added `isPanelDragging` state driven by `onDragging` callback on the ResizableHandle. When dragging, a transparent overlay div covers the preview iframe to block it from intercepting pointer events.

Also adds tests for the Preview/Code toggle button behavior.